### PR TITLE
use shr-string-pixel-width replace string-pixed-width

### DIFF
--- a/org-center-headings.el
+++ b/org-center-headings.el
@@ -54,7 +54,7 @@
           (beg (line-beginning-position)))
       (if center
           (let* ((heading (buffer-substring beg end))
-                 (length (/ (string-pixel-width heading) 2)))
+                 (length (/ (shr-string-pixel-width heading) 2)))
             (put-text-property
              beg (1+ beg) 'display `(space :align-to (- center (,length)))))
         (remove-text-properties beg (1+ beg) '(display nil))))))


### PR DESCRIPTION

My emacs version is 27.1 don't have  `string-pixed-width` so use `shr-string-pixel-width` replace
![image](https://user-images.githubusercontent.com/45911286/163675890-8209578f-dcb4-4658-81b9-17b6668cefe5.png)
